### PR TITLE
Fixes 'buffer.get is not a function'

### DIFF
--- a/lib/last-partial-of.js
+++ b/lib/last-partial-of.js
@@ -19,7 +19,7 @@
       ;
 
     for (i = 0; i < len; i += 1) {
-      if (buffer.get(from + i) !== pattern.get(count)) {
+      if (buffer[from + i] !== pattern[count]) {
         if (count > 0) {
           // if there is a string such as "\r\n--\r\n--withBoundary"
           // then the second \r is not expected and we must back up


### PR DESCRIPTION
When use with formaline library images upload fails with the error `TypeError: buffer.get is not a function`. Didn't find node.js `Buffer.get` method, so changed to default `[index]` access.
